### PR TITLE
display video player when the corresponding thumbnail is clicked

### DIFF
--- a/src/video-player/video-player.css
+++ b/src/video-player/video-player.css
@@ -1,0 +1,3 @@
+.${VIDEO_PLAYER_CLASSNAME} {
+    max-width: calc(100% - 42px);
+}

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -1,0 +1,51 @@
+(function() {
+  'use strict';
+
+  /*
+  Список расширений файлов, преобразуемых в видеопроигрыватели.
+  */
+  const EXTENSIONS = ['webm', 'mp4', 'ogv'];
+  /*
+  Класс CSS, применяемый для видеопроигрывателей.
+  */
+  const VIDEO_PLAYER_CLASSNAME = 'iichan-video-player';
+
+  function addListeners(e) {
+    function onThumbnailClick(e) {
+      let parentNode = e.currentTarget.parentNode;
+      let vp = document.createElement('video');
+      vp.src = e.currentTarget.href;
+      vp.classList.add(VIDEO_PLAYER_CLASSNAME);
+      parentNode.instertBefore(vp, e.currentTarget);
+      parentNode.removeChild(e.currentTarget);
+      e.preventDefault();
+    }
+
+    const thumbs = document.querySelectorAll('.thumb');
+    for (let img of thumbs) {
+      let a = img.parentNode;
+      if (!a) continue;
+      let videoExt = a.href.split('.').pop();
+      if (!EXTENSIONS.includes(videoExt)) continue;
+      a.addEventListener('click', onThumbnailClick);
+    }
+  }
+
+  function appendCSS() {
+    document.head.insertAdjacentHTML('beforeend',
+      `<style type="text/css">
+        //=include video-player.css
+      </style>`);
+  }
+
+  function init() {
+    appendCSS();
+    addListeners();
+  }
+
+  if (document.body) {
+    init();
+  } else {
+    document.addEventListener('DOMContentLoaded', init);
+  }
+})();

--- a/src/video-player/video-player.meta.js
+++ b/src/video-player/video-player.meta.js
@@ -1,0 +1,13 @@
+// ==UserScript==
+// @name         Video players on iichan
+// @namespace    http://iichan.hk/
+// @license      MIT
+// @version      0.2
+// @description  Video players on thumbnail click
+// @icon         http://iichan.hk/favicon.ico
+// @updateURL    https://raw.github.com/WagonOfDoubt/iichan-extensions/master/dist/userscript/iichan-video-player.user.js
+// @author       Mithgol
+// @match        http://iichan.hk/*
+// @match        https://iichan.hk/*
+// @grant        none
+// ==/UserScript==


### PR DESCRIPTION
This script is the client-side part of a solution for the problem outlined at http://410chan.org/dev/res/17662.html on 410chan (regarding video players on iichan).

It adheres to the standard established by `expand-images` and introduces similar (yet necessarily different) behaviour for (future) video players.

This pull request is intentionally kept small by containing only the `src` part of the changes (without any `dist` that may result from them).