### PR TITLE
video player must autoplay and loop, be muted, have controls & poster

### DIFF
--- a/src/video-player/video-player.css
+++ b/src/video-player/video-player.css
@@ -1,7 +1,0 @@
-.${VIDEO_PLAYER_CLASSNAME} {
-  max-width: 100%;
-  height: auto;
-  box-sizing: border-box;
-  margin: 0;
-  padding: 2px 20px
-}

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -13,7 +13,12 @@
   const onThumbnailClick = (e) => {
     const parentNode = e.currentTarget.parentNode;
     const vp = document.createElement('video');
+    vp.poster = e.currentTarget.dataset.thumbSrc;
     vp.src = e.currentTarget.href;
+    vp.autoplay = true;
+    vp.controls = true;
+    vp.loop = true;
+    vp.muted = true;
     vp.classList.add(VIDEO_PLAYER_CLASSNAME);
     parentNode.insertBefore(vp, e.currentTarget);
     parentNode.removeChild(e.currentTarget);
@@ -27,16 +32,21 @@
       if (!a) continue;
       const videoExt = a.href.split('.').pop();
       if (!EXTENSIONS.includes(videoExt)) continue;
+      a.dataset.thumbSrc = img.src;
       a.addEventListener('click', onThumbnailClick);
     }
   };
 
-  const appendCSS = () => {
-    document.head.insertAdjacentHTML('beforeend',
-      `<style type="text/css">
-        //=include video-player.css
-      </style>`);
-  };
+  const appendCSS = () => document.head.insertAdjacentHTML(
+    'beforeend',
+    `<style type="text/css">.${VIDEO_PLAYER_CLASSNAME} {
+      max-width: 100%;
+      height: auto;
+      box-sizing: border-box;
+      margin: 0;
+      padding: 2px 20px;
+    }</style>`
+  );
 
   const init = () => {
     if (document.querySelector('#de-main')) return;


### PR DESCRIPTION
Imageboard readers are entitled to have somewhat better control over their video players (pause, rewind, etc.), hence here's a bit opinionated answer “yes” to all of my questions from http://410chan.org/dev/res/17662.html#17687

(Of course, the code here intentially leaves an opportunity for server-side overrides. For example, an imageboard's admin still has all the power to refuse an upload of a video file containing a soundtrack, but that's server-side, while client-side here does not impose such a restriction and merely starts a muted player that could later be unmuted manually.)

This patch moves CSS code from an external file to insides of the main JS for immediate visibility.