### PR TITLE
do not use regexps when looking for images' extensions

### DIFF
--- a/src/expand-images/expand-images.main.js
+++ b/src/expand-images/expand-images.main.js
@@ -26,7 +26,7 @@
     for (const img of thumbs) {
       const a = img.parentNode;
       if (!a) continue;
-      const imageExt = a.href.match(/\w*$/).toString();
+      const imageExt = a.href.split('.').pop();
       if (!EXTENSIONS.includes(imageExt)) continue;
       img.dataset.thumbWidth = img.getAttribute('width');
       img.dataset.thumbHeight = img.getAttribute('height');


### PR DESCRIPTION
This pull request is a one-liner that replaces regular expressions search with looking for a specific character (a dot).

Rationale:

* Regex engine tends to work slower than a search for one specific character.

* An “extension” of a filename is precisely defined as “the part after the last dot”, not just “the last word”, hence it mustn't be tricked into thinking that `foobar.bazquuxыыыыjpg` has an extension of a JPEG picture.