### PR TITLE
bugfix: vanilla JavaScript does not have any `insertAfter`

### DIFF
--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -30,7 +30,7 @@
       vp.muted = true;
       vp.classList.add(VIDEO_PLAYER_CLASSNAME);
       e.currentTarget.dataset.videoPlayer = vp;
-      parentNode.insertAfter(vp, e.currentTarget);
+      parentNode.insertBefore(vp, e.currentTarget.nextSibling);
       e.currentTarget.innerHTML = '[Свернуть видео]';
     }
 


### PR DESCRIPTION
My previous code had a fault: vanilla JavaScript does not have any `insertAfter`.

However, the standard of [`.nextSibling`](https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#attribute-nextSibling) is either next sibling (if present) or `null`, which is precisely what `.insertBefore` needs to insert after `e.currentTarget`.