### PR TITLE
fix some bugs in my video player's script

### DIFF
--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -13,26 +13,26 @@
   const onThumbnailClick = e => {
     const parentNode = e.currentTarget.parentNode;
 
-    if( e.currentTarget.dataset.videoMode === 'on' ){
-      e.currentTarget.dataset.videoMode = 'off';
+    if( e.currentTarget.videoMode === 'on' ){
+      e.currentTarget.videoMode = 'off';
 
       parentNode.removeChild(document.getElementById(
-         e.currentTarget.dataset.vpid
+         e.currentTarget.videoplayerid
       ));
-      e.currentTarget.innerHTML = e.currentTarget.dataset.thumbHTML;
+      e.currentTarget.innerHTML = e.currentTarget.thumbHTML;
     } else {
-      e.currentTarget.dataset.videoMode = 'on';
+      e.currentTarget.videoMode = 'on';
 
       const vp = document.createElement('video');
       vp.id = 'video' + ('' + Math.random()).replace(/\D/g, '');
-      vp.poster = e.currentTarget.dataset.thumbSrc;
+      vp.poster = e.currentTarget.thumbSrc;
       vp.src = e.currentTarget.href;
       vp.autoplay = true;
       vp.controls = true;
       vp.loop = true;
       vp.muted = true;
       vp.classList.add(VIDEO_PLAYER_CLASSNAME);
-      e.currentTarget.dataset.vpid = vp.id;
+      e.currentTarget.videoplayerid = vp.id;
       parentNode.insertBefore(vp, e.currentTarget.nextSibling);
       e.currentTarget.innerHTML = '[Свернуть видео]';
     }
@@ -47,8 +47,8 @@
       if (!a) continue;
       const videoExt = a.href.split('.').pop();
       if (!EXTENSIONS.includes(videoExt)) continue;
-      a.dataset.thumbSrc = img.src;
-      a.dataset.thumbHTML = a.innerHTML;
+      a.thumbSrc = img.src;
+      a.thumbHTML = a.innerHTML;
       a.addEventListener('click', onThumbnailClick);
     }
   };

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -13,15 +13,18 @@
   const onThumbnailClick = e => {
     const parentNode = e.currentTarget.parentNode;
 
-    if( e.currentTarget.dataset.videoMode ){
-      e.currentTarget.dataset.videoMode = false;
+    if( e.currentTarget.dataset.videoMode === 'on' ){
+      e.currentTarget.dataset.videoMode = 'off';
 
-      parentNode.removeChild(e.currentTarget.dataset.videoPlayer);
+      parentNode.removeChild(document.getElementById(
+         e.currentTarget.dataset.vpid
+      ));
       e.currentTarget.innerHTML = e.currentTarget.dataset.thumbHTML;
     } else {
-      e.currentTarget.dataset.videoMode = true;
+      e.currentTarget.dataset.videoMode = 'on';
 
       const vp = document.createElement('video');
+      vp.id = 'video' + ('' + Math.random()).replace(/\D/g, '');
       vp.poster = e.currentTarget.dataset.thumbSrc;
       vp.src = e.currentTarget.href;
       vp.autoplay = true;
@@ -29,7 +32,7 @@
       vp.loop = true;
       vp.muted = true;
       vp.classList.add(VIDEO_PLAYER_CLASSNAME);
-      e.currentTarget.dataset.videoPlayer = vp;
+      e.currentTarget.dataset.vpid = vp.id;
       parentNode.insertBefore(vp, e.currentTarget.nextSibling);
       e.currentTarget.innerHTML = '[Свернуть видео]';
     }


### PR DESCRIPTION
The script is rewritten to store JavaScript strings (of `DOMString` type) as the author of http://410chan.org/dev/res/17662.html#17743 suggested.

Additionally the script no longer uses the [`HTMLElement.dataset` feature](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) because it's not supported in Internet Explorer before IE11 (while the support for [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) starts with IE9).