### PR TITLE
future proof width×height regular expression

### DIFF
--- a/src/expand-images/expand-images.main.js
+++ b/src/expand-images/expand-images.main.js
@@ -37,6 +37,7 @@
       const filesize = post.querySelector('.filesize > em');
       if (!filesize) continue;
       const WxH = filesize.innerText.match(/(\d+)x(\d+)/);
+      if( WxH === null ) continue;
       img.dataset.fullWidth = WxH[1];
       img.dataset.fullHeight = WxH[2];
       a.addEventListener('click', onThumbnailClick);

--- a/src/expand-images/expand-images.main.js
+++ b/src/expand-images/expand-images.main.js
@@ -36,7 +36,7 @@
       if (!post) continue;
       const filesize = post.querySelector('.filesize > em');
       if (!filesize) continue;
-      const WxH = filesize.innerText.match(/(\d*)x(\d*)/);
+      const WxH = filesize.innerText.match(/(\d+)x(\d+)/);
       img.dataset.fullWidth = WxH[1];
       img.dataset.fullHeight = WxH[2];
       a.addEventListener('click', onThumbnailClick);


### PR DESCRIPTION
This patch introduces a slightly different version of width×height regular expression that ensures at least one digit in both.

The rationale here is that the absense of width×height given from the server may indicate a specially crafted source image file that causes an error in the server soft when that tries to determine the image's width or height or thumbnail (such as https://imagetragick.com/ in the past) and thus the image should probably not be inlined in a page that possibly contains sensitive information (such as the tripcode sometimes) where the file may negatively affect the web browser as much as (presumably) it affected the server side.