### PR TITLE
`MutationObserver` doesn't exist in IE below IE11, use jQuery instead

### DIFF
--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -30,8 +30,8 @@
     jqScript = document.createElement('script');
     jqScript.crossOrigin = 'anonymous';
     jqScript.id = 'iichanJQ';
-    jqScript.integrity = 'sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=';
-    jqScript.src = 'https://code.jquery.com/jquery-3.2.1.js';
+    jqScript.integrity = 'sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=';
+    jqScript.src = 'https://code.jquery.com/jquery-3.2.1.min.js';
     jqScript.addEventListener('load', () => jQuery(callbackJQ));
     document.body.appendChild(jqScript);
   };

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -4,7 +4,7 @@
   // Список расширений файлов, преобразуемых в видеопроигрыватели:
   const VIDEO_EXTENSIONS = ['webm', 'mp4', 'ogv'];
   // Класс тега отключателя видеопроигрывателей:
-  const VIDEO_PLAYER_TOGGLE = 'iichan-toggle-video-player';
+  const VIDEO_TOGGLE = 'iichan-toggle-video-player';
   // Класс тега видеопроигрывателей:
   const VIDEO_PLAYER_CLASSNAME = 'iichan-video-player';
   // Стиль тега видеопроигрывателей:
@@ -48,9 +48,6 @@
       const vpMode = $a.data('vpMode');
 
       const renderVideoPlayer = () => {
-        $a.addClass(VIDEO_PLAYER_TOGGLE);
-        $a.data('thumbHTML', $a.html());
-
         const $vp = $('<video>').attr({
           poster: $img.attr('src'),
           src: $a.attr('href'),
@@ -60,7 +57,10 @@
           muted: true
         }).addClass(VIDEO_PLAYER_CLASSNAME);
 
-        $a.data('videoPlayer', $vp).after($vp).html(
+        $a.addClass(VIDEO_TOGGLE).data({
+          thumbHTML: $a.html(),
+          videoPlayer: $vp
+        }).after($vp).html(
           '<div style="padding: 2px 20px;">[Свернуть видео]</div>'
         );
         return false; // do not proparate the click
@@ -80,11 +80,11 @@
       }
     });
 
-    $('body').on('click', '.' + VIDEO_PLAYER_TOGGLE, function(){
+    $('body').on('click', '.' + VIDEO_TOGGLE, function(){
       const $a = $(this);
-      $a.removeClass(VIDEO_PLAYER_TOGGLE);
-      $a.data('videoPlayer').remove();
-      $a.html( $a.data('thumbHTML') );
+      $a.removeClass(VIDEO_TOGGLE).html(
+        $a.data('thumbHTML') 
+      ).data('videoPlayer').remove();
       return false; // do not propagate the click
     });
   });

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -83,7 +83,7 @@
     $('body').on('click', '.' + VIDEO_PLAYER_TOGGLE, function(){
       const $a = $(this);
       $a.removeClass(VIDEO_PLAYER_TOGGLE);
-      $( $a.data('videoPlayer') ).remove();
+      $a.data('videoPlayer').remove();
       $a.html( $a.data('thumbHTML') );
       return false; // do not propagate the click
     });

--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -1,58 +1,13 @@
 (() => {
   'use strict';
 
-  /*
-  Список расширений файлов, преобразуемых в видеопроигрыватели.
-  */
-  const EXTENSIONS = ['webm', 'mp4', 'ogv'];
-  /*
-  Класс CSS, применяемый для видеопроигрывателей.
-  */
+  // Список расширений файлов, преобразуемых в видеопроигрыватели:
+  const VIDEO_EXTENSIONS = ['webm', 'mp4', 'ogv'];
+  // Класс тега отключателя видеопроигрывателей:
+  const VIDEO_PLAYER_TOGGLE = 'iichan-toggle-video-player';
+  // Класс тега видеопроигрывателей:
   const VIDEO_PLAYER_CLASSNAME = 'iichan-video-player';
-
-  const onThumbnailClick = e => {
-    const parentNode = e.currentTarget.parentNode;
-
-    if( e.currentTarget.videoMode === 'on' ){
-      e.currentTarget.videoMode = 'off';
-
-      parentNode.removeChild(document.getElementById(
-         e.currentTarget.videoplayerid
-      ));
-      e.currentTarget.innerHTML = e.currentTarget.thumbHTML;
-    } else {
-      e.currentTarget.videoMode = 'on';
-
-      const vp = document.createElement('video');
-      vp.id = 'video' + ('' + Math.random()).replace(/\D/g, '');
-      vp.poster = e.currentTarget.thumbSrc;
-      vp.src = e.currentTarget.href;
-      vp.autoplay = true;
-      vp.controls = true;
-      vp.loop = true;
-      vp.muted = true;
-      vp.classList.add(VIDEO_PLAYER_CLASSNAME);
-      e.currentTarget.videoplayerid = vp.id;
-      parentNode.insertBefore(vp, e.currentTarget.nextSibling);
-      e.currentTarget.innerHTML = '<div style="padding: 2px 20px;">[Свернуть видео]</div>';
-    }
-
-    e.preventDefault();
-  };
-
-  const addListeners = rootNode => {
-    const thumbs = (rootNode || document).querySelectorAll('.thumb');
-    for (const img of thumbs) {
-      const a = img.parentNode;
-      if (!a) continue;
-      const videoExt = a.href.split('.').pop();
-      if (!EXTENSIONS.includes(videoExt)) continue;
-      a.thumbSrc = img.src;
-      a.thumbHTML = a.innerHTML;
-      a.addEventListener('click', onThumbnailClick);
-    }
-  };
-
+  // Стиль тега видеопроигрывателей:
   const appendCSS = () => document.head.insertAdjacentHTML(
     'beforeend',
     `<style type="text/css">.${VIDEO_PLAYER_CLASSNAME} {
@@ -63,25 +18,74 @@
       margin: 0;
     }</style>`
   );
+  // Загрузчик jQuery с контролем целостности:
+  const jqReady = callbackJQ => {
+    if( typeof jQuery === 'function' ) return jQuery(callbackJQ);
 
-  const init = () => {
-    if (document.querySelector('#de-main')) return;
-    appendCSS();
-    addListeners();
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        for (const node of mutation.addedNodes) {
-          if (!node.querySelectorAll) return;
-          addListeners(node);
-        }
-      });
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
+    var jqScript = document.getElementById('iichanJQ');
+    if( jqScript ) return jqScript.addEventListener(
+       'load', () => jQuery(callbackJQ)
+    );
+
+    jqScript = document.createElement('script');
+    jqScript.crossOrigin = 'anonymous';
+    jqScript.id = 'iichanJQ';
+    jqScript.integrity = 'sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=';
+    jqScript.src = 'https://code.jquery.com/jquery-3.2.1.js';
+    jqScript.addEventListener('load', () => jQuery(callbackJQ));
+    document.body.appendChild(jqScript);
   };
 
-  if (document.body) {
-    init();
-  } else {
-    document.addEventListener('DOMContentLoaded', init);
-  }
+  jqReady(function(){
+    const $ = jQuery;
+
+    if( $('#de-main').length > 0 ) return;
+    appendCSS();
+
+    $('body').on('click', '.thumb', function(){
+      const $img = $(this);
+      const $a = $img.closest('a');
+      const vpMode = $a.data('vpMode');
+
+      const renderVideoPlayer = () => {
+        $a.addClass(VIDEO_PLAYER_TOGGLE);
+        $a.data('thumbHTML', $a.html());
+
+        const $vp = $('<video>').attr({
+          poster: $img.attr('src'),
+          src: $a.attr('href'),
+          autoplay: true,
+          controls: true,
+          loop: true,
+          muted: true
+        }).addClass(VIDEO_PLAYER_CLASSNAME);
+
+        $a.data('videoPlayer', $vp).after($vp).html(
+          '<div style="padding: 2px 20px;">[Свернуть видео]</div>'
+        );
+        return false; // do not proparate the click
+      };
+
+      if( vpMode === 'off' ) return true; // propagate the click
+      if( vpMode === 'on' ) return renderVideoPlayer();
+
+      // determine (once) if a video player is necessary:
+      const videoExt = $a.attr('href').split('.').pop();
+      if( VIDEO_EXTENSIONS.includes(videoExt) ){
+        $a.data('vpMode', 'on');
+        return renderVideoPlayer();
+      } else {
+        $a.data('vpMode', 'off');
+        return true;
+      }
+    });
+
+    $('body').on('click', '.' + VIDEO_PLAYER_TOGGLE, function(){
+      const $a = $(this);
+      $a.removeClass(VIDEO_PLAYER_TOGGLE);
+      $( $a.data('videoPlayer') ).remove();
+      $a.html( $a.data('thumbHTML') );
+      return false; // do not propagate the click
+    });
+  });
 })();


### PR DESCRIPTION
`MutationObserver` constructor [is not present in Internet Explorer older than IE11](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#Browser_compatibility), but the `<video>` tag [is supported in IE9 and newer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Browser_compatibility) and thus the script should also support those versions of Internet Explorer.

Here's a new version of the script that takes advantage of [jQuery](https://jquery.com/)'s [event delegation](http://api.jquery.com/on/#direct-and-delegated-events) and thus should also be able to react successfully on click events even when new `.thumb` elements appear on a web page.