### PR TITLE
do not mute the video player

### DIFF
--- a/src/video-player/video-player.main.js
+++ b/src/video-player/video-player.main.js
@@ -30,7 +30,6 @@
       vp.autoplay = true;
       vp.controls = true;
       vp.loop = true;
-      vp.muted = true;
       vp.classList.add(VIDEO_PLAYER_CLASSNAME);
       e.currentTarget.videoplayerid = vp.id;
       parentNode.insertBefore(vp, e.currentTarget.nextSibling);

--- a/src/video-player/video-player.meta.js
+++ b/src/video-player/video-player.meta.js
@@ -2,7 +2,7 @@
 // @name         [IIchan] Video player
 // @namespace    http://iichan.hk/
 // @license      MIT
-// @version      0.4
+// @version      0.5
 // @description  Video players on thumbnail click
 // @icon         http://iichan.hk/favicon.ico
 // @updateURL    https://raw.github.com/WagonOfDoubt/iichan-extensions/master/dist/userscript/iichan-video-player.meta.js


### PR DESCRIPTION
Currently imageboards either forbid audio tracks in video files (using server-side constraints) or allow them.

In the former case it's unnecessary for the video player to be muted additionally (because the file itself won't contain audio anyway).

In the latter case it's unreasonable for this extension to impose its own constraint.

It also feels more natural to autoplay the audio without any additional click on the ”Unmute” button (for the same reason we autoplay the video instead of waiting for a click on the “Play” button).

Historically speaking, a muted video player has been proposed in http://410chan.org/dev/res/17662.html#17687 and http://410chan.org/dev/res/17662.html#17696 as an attempt to find a compromise against the total ban imposed on audio tracks. However, that compromise has been utterly rejected in http://410chan.org/dev/res/17662.html#17777 and additionally in http://410chan.org/dev/res/17662.html#17793 and thus such muteness is no longer necessary at all.